### PR TITLE
fix: export/import string key corrected - fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,7 +273,7 @@ function getConfig() {
 
 // eslint-disable-next-line no-unused-vars
 function copySave() {
-  const saveFile = btoa(localStorage.getItem('everything'));
+  const saveFile = btoa(localStorage.getItem('everythin'));
   prompt('Save Data:', saveFile);
 }
 
@@ -284,7 +284,7 @@ function importSave() {
     importing = atob(importing);
     loadGame(importing.split(','));
   } catch (err) {
-    loadGame(localStorage.getItem("everythin").split(','));
+    loadGame(localStorage.getItem('everythin').split(','));
   }
 }
 


### PR DESCRIPTION
Looks like `copySave` was outputting the wrong key from localStorage. The save is saved under `everythin`. If/when you're willing to break saves, I'd suggest changing to `timeIdle` or something similar, and implementing a load check for a save present in `everythin`, converting everyone to the new key.